### PR TITLE
Bugfix with multiple specs producing null values in reporter results

### DIFF
--- a/jasmine-jsreporter.js
+++ b/jasmine-jsreporter.js
@@ -123,7 +123,7 @@
 
         reportRunnerResults: function (runner) {
             var suites = runner.suites(),
-                i, ilen;
+                i, j, ilen;
 
             // Attach results to the "jasmine" object to make those results easy to scrap/find
             jasmine.runnerResults = {
@@ -133,13 +133,14 @@
             };
 
             // Loop over all the Suites
-            for (i = 0, ilen = suites.length; i < ilen; ++i) {
+            for (i = 0, ilen = suites.length, j = 0; i < ilen; ++i) {
                 if (suites[i].parentSuite === null) {
-                    jasmine.runnerResults.suites[i] = getSuiteData(suites[i]);
+                    jasmine.runnerResults.suites[j] = getSuiteData(suites[i]);
                     // If 1 suite fails, the whole runner fails
-                    jasmine.runnerResults.passed = !jasmine.runnerResults.suites[i].passed ? false : jasmine.runnerResults.passed;
+                    jasmine.runnerResults.passed = !jasmine.runnerResults.suites[j].passed ? false : jasmine.runnerResults.passed;
                     // Add up all the durations
-                    jasmine.runnerResults.durationSec += jasmine.runnerResults.suites[i].durationSec;
+                    jasmine.runnerResults.durationSec += jasmine.runnerResults.suites[j].durationSec;
+                    j++;
                 }
             }
 


### PR DESCRIPTION
When using multiple nested specs, due using only one variable `i` for iteration the suites array produced in the json report contains`undefined` values.

Before fix:
http://extensa.pl/projekty/github/jsreporter/indexMulti.html

```
> jasmine.getJSReport()
Object {suites: Array[4], durationSec: 0.045, passed: true}
> jasmine.getJSReport().suites
[Object, undefined × 2, Object]
```

After fix:
http://extensa.pl/projekty/github/jsreporter/indexMultiFix.html

```
> jasmine.getJSReport()
Object {suites: Array[2], durationSec: 0.042, passed: true}
```

Also, I've updated jasmine submodule in the example to current version 1.3.1.
