### PR TITLE
Adding failures to the json report

### DIFF
--- a/jasmine-jsreporter.js
+++ b/jasmine-jsreporter.js
@@ -78,7 +78,8 @@
                 skipped : specs[i].results().skipped,
                 passedCount : specs[i].results().passedCount,
                 failedCount : specs[i].results().failedCount,
-                totalCount : specs[i].results().totalCount
+                totalCount : specs[i].results().totalCount,
+                failures: specs[i].results().getItems().filter(function(v) { return !v.passed_; })
             };
             suiteData.passed = !suiteData.specs[i].passed ? false : suiteData.passed;
             suiteData.durationSec += suiteData.specs[i].durationSec;


### PR DESCRIPTION
Added a failures field for each spec in the json report, which is an array of all failed "expect"s, including expected and actual values, and stack trace.
