### PR TITLE
Re-write for jasmine2's event-driven style, in a way that doesn't rely on jasmine internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Jasmine JS-Reporter
 
-- - -
-This is `jasmine-2.0` branch and changes to this library to support
-[this new version of Jasmine](http://jasmine.github.io/2.0/introduction.html)
-should go in there.
-- - -
-
 This is a Jasmine Reporter, designed to simplify the extraction of test results from the Page.
 It's tailored with _Test Reporting Automation_ in mind.
 
@@ -55,15 +49,17 @@ and looks like the following:
 
 After that, you can just extract it from the page.
 
-## How do I download it and check it works
+## Usage
 
-1. Download the code:
-    * `git clone http://github.com/detro/jasmine-jsreporter.git`
-2. Include the reporter in your page running Jasmine tests with something like:
+1. Clone this repository, and include the reporter in your page running Jasmine tests:
     * `<script src="path/to/jasmine-jsreporter.js" type="text/javascript"></script>`
-3. Open your [WebInspector](http://trac.webkit.org/wiki/WebInspector), [Firebug](http://getfirebug.com/) or whatever you use
-4. On the console, type:
-    * `jasmine.getJSReport ()`
+2. Tell jasmine to use the reporter
+    * For Jasmine 1.x: `jasmine.getEnv().addReporter(new jasmine.JSReporter())`
+    * For Jasmine 2.0: `jasmine.getEnv().addReporter(new jasmine.JSReporter2())`
+3. Run your tests as normal
+4. Go to your browser console, via [WebInspector](http://trac.webkit.org/wiki/WebInspector), [Firebug](http://getfirebug.com/), etc.
+     On the console, type:
+     * `jasmine.getJSRepor t()`
 5. Check that you get an Object back (should look like the above one)
 6. You are done!
 

--- a/jasmine-jsreporter.js
+++ b/jasmine-jsreporter.js
@@ -53,7 +53,7 @@
     JSReporter compatible with Jasmine 2.0.0's event-driven style.
   */
 
-  jasmine.JSReporter = function () {
+  jasmine.JSReporter2 = function () {
     _.bindAll(this, 'getJSReport', 'getJSReportAsString');
 
     this.specs  = {};
@@ -67,7 +67,7 @@
     jasmine.getJSReportAsString = this.getJSReportAsString;
   };
 
-  var JSR = jasmine.JSReporter.prototype;
+  var JSR = jasmine.JSReporter2.prototype;
 
   // Reporter API methods
   // --------------------

--- a/jasmine-jsreporter.js
+++ b/jasmine-jsreporter.js
@@ -32,6 +32,158 @@
     throw new Error("[Jasmine JSReporter] 'Jasmine' library not found");
   }
 
+  // ------------------------------------------------------------------------
+  // Jasmine JSReporter for Jasmine 1.x
+  // ------------------------------------------------------------------------
+
+  /**
+   * Calculate elapsed time, in Seconds.
+   * @param startMs Start time in Milliseconds
+   * @param finishMs Finish time in Milliseconds
+   * @return Elapsed time in Seconds */
+  function elapsedSec (startMs, finishMs) {
+      return (finishMs - startMs) / 1000;
+  }
+
+  /**
+   * Round an amount to the given number of Digits.
+   * If no number of digits is given, than '2' is assumed.
+   * @param amount Amount to round
+   * @param numOfDecDigits Number of Digits to round to. Default value is '2'.
+   * @return Rounded amount */
+  function round (amount, numOfDecDigits) {
+      numOfDecDigits = numOfDecDigits || 2;
+      return Math.round(amount * Math.pow(10, numOfDecDigits)) / Math.pow(10, numOfDecDigits);
+  }
+
+  /**
+   * Create a new array which contains only the failed items.
+   * @param items Items which will be filtered
+   * @returns {Array} of failed items */
+  function failures (items) {
+      var fs = [], i, v;
+      for (i = 0; i < items.length; i += 1) {
+          v = items[i];
+          if (!v.passed_) {
+              fs.push(v);
+          }
+      }
+      return fs;
+  }
+
+  /**
+   * Collect information about a Suite, recursively, and return a JSON result.
+   * @param suite The Jasmine Suite to get data from
+   */
+  function getSuiteData (suite) {
+      var suiteData = {
+              description : suite.description,
+              durationSec : 0,
+              specs: [],
+              suites: [],
+              passed: true
+          },
+          specs = suite.specs(),
+          suites = suite.suites(),
+          i, ilen;
+
+      // Loop over all the Suite's Specs
+      for (i = 0, ilen = specs.length; i < ilen; ++i) {
+          suiteData.specs[i] = {
+              description : specs[i].description,
+              durationSec : specs[i].durationSec,
+              passed : specs[i].results().passedCount === specs[i].results().totalCount,
+              skipped : specs[i].results().skipped,
+              passedCount : specs[i].results().passedCount,
+              failedCount : specs[i].results().failedCount,
+              totalCount : specs[i].results().totalCount,
+              failures: failures(specs[i].results().getItems())
+          };
+          suiteData.passed = !suiteData.specs[i].passed ? false : suiteData.passed;
+          suiteData.durationSec += suiteData.specs[i].durationSec;
+      }
+
+      // Loop over all the Suite's sub-Suites
+      for (i = 0, ilen = suites.length; i < ilen; ++i) {
+          suiteData.suites[i] = getSuiteData(suites[i]); //< recursive population
+          suiteData.passed = !suiteData.suites[i].passed ? false : suiteData.passed;
+          suiteData.durationSec += suiteData.suites[i].durationSec;
+      }
+
+      // Rounding duration numbers to 3 decimal digits
+      suiteData.durationSec = round(suiteData.durationSec, 4);
+
+      return suiteData;
+  }
+
+  var JSReporter =  function () {
+  };
+
+  JSReporter.prototype = {
+      reportRunnerStarting: function (runner) {
+          // Nothing to do
+      },
+
+      reportSpecStarting: function (spec) {
+          // Start timing this spec
+          spec.startedAt = new Date();
+      },
+
+      reportSpecResults: function (spec) {
+          // Finish timing this spec and calculate duration/delta (in sec)
+          spec.finishedAt = new Date();
+          // If the spec was skipped, reportSpecStarting is never called and spec.startedAt is undefined
+          spec.durationSec = spec.startedAt ? elapsedSec(spec.startedAt.getTime(), spec.finishedAt.getTime()) : 0;
+      },
+
+      reportSuiteResults: function (suite) {
+          // Nothing to do
+      },
+
+      reportRunnerResults: function (runner) {
+          var suites = runner.suites(),
+              i, j, ilen;
+
+          // Attach results to the "jasmine" object to make those results easy to scrap/find
+          jasmine.runnerResults = {
+              suites: [],
+              durationSec : 0,
+              passed : true
+          };
+
+          // Loop over all the Suites
+          for (i = 0, ilen = suites.length, j = 0; i < ilen; ++i) {
+              if (suites[i].parentSuite === null) {
+                  jasmine.runnerResults.suites[j] = getSuiteData(suites[i]);
+                  // If 1 suite fails, the whole runner fails
+                  jasmine.runnerResults.passed = !jasmine.runnerResults.suites[j].passed ? false : jasmine.runnerResults.passed;
+                  // Add up all the durations
+                  jasmine.runnerResults.durationSec += jasmine.runnerResults.suites[j].durationSec;
+                  j++;
+              }
+          }
+
+          // Decorate the 'jasmine' object with getters
+          jasmine.getJSReport = function () {
+              if (jasmine.runnerResults) {
+                  return jasmine.runnerResults;
+              }
+              return null;
+          };
+          jasmine.getJSReportAsString = function () {
+              return JSON.stringify(jasmine.getJSReport());
+          };
+      }
+  };
+
+  // export public
+  jasmine.JSReporter = JSReporter;
+
+
+  // ------------------------------------------------------------------------
+  // Jasmine JSReporter for Jasmine 2.0
+  // ------------------------------------------------------------------------
+
   /*
     Simple timer implementation
   */
@@ -48,10 +200,6 @@
     }
     return new Date().getTime() - this.startTime;
   };
-
-  /*
-    JSReporter compatible with Jasmine 2.0.0's event-driven style.
-  */
 
   jasmine.JSReporter2 = function () {
     _.bindAll(this, 'getJSReport', 'getJSReportAsString');


### PR DESCRIPTION
Also works with [jasmine#575](/pivotal/jasmine/pull/575) for totalCount and passedCount, which are currently missing.

See #7 for context
