### PR TITLE
PR: Changes for Jasmine 2.0.1 - tracking total expectations, passed expectations, failed expectations

### DIFF
--- a/jasmine-jsreporter.js
+++ b/jasmine-jsreporter.js
@@ -286,10 +286,8 @@
     spec.skipped = spec.status === 'pending';
     spec.passed = spec.skipped || spec.status === 'passed';
 
-    // totalCount and passedCount will be populated if/when jasmine#575 gets accepted
-    spec.totalCount = spec.totalExpectations || 0;
-    spec.passedCount = spec.passedExpectations ? spec.passedExpectations.length : 0;
-
+    spec.totalCount = spec.passedExpectations.length + spec.failedExpectations.length;
+    spec.passedCount = spec.passedExpectations.length;
     spec.failedCount = spec.failedExpectations.length;
     spec.failures = [];
 


### PR DESCRIPTION
Hey again @detro

Jasmine merged in my PR [jasmine#575](https://github.com/pivotal/jasmine/pull/575) for [jasmine-2.0.1](https://github.com/pivotal/jasmine/blob/master/release_notes/2.0.1.md#features).

I've included some small changes for JSReporter2 to bring it in-line with jasmine 2.0.1
